### PR TITLE
fix(featchers): handle exceptions gracefully if possible

### DIFF
--- a/src/infectApp.integration.js
+++ b/src/infectApp.integration.js
@@ -65,6 +65,11 @@ test('throws with any invalid config', (t) => {
 
     mockFetch();
 
+    // This displays a lot of errors in the console; send them to the sink for this test or
+    // test output will be barely readable.
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
     // Only test fields that are called in intialize.
     const relevantFields = ['bacteria', 'antibiotics', 'resistances', 'substanceClasses',
         'regions', 'countries', 'ageGroups', 'hospitalStatus'];
@@ -80,8 +85,9 @@ test('throws with any invalid config', (t) => {
     const allPromises = promises.reduce((prev, item) => prev.then(() => item), Promise.resolve());
 
     allPromises.then(() => {
-        t.end();
         resetFetch();
+        console.error = originalConsoleError;
+        t.end();        
     });
 
 });

--- a/src/infectApp.js
+++ b/src/infectApp.js
@@ -108,6 +108,7 @@ export default class InfectApp {
             { headers: { select: 'substance.*, substance.substanceClass.*' } },
             [this.substanceClasses],
             this.substanceClasses,
+            this.errorHandler.handle.bind(this.errorHandler),
         );
         const antibioticPromise = antibioticsFetcher.getData();
         log('Fetching data for antibiotics.');
@@ -131,6 +132,7 @@ export default class InfectApp {
                 antibiotics: this.antibiotics,
                 bacteria: this.bacteria,
             },
+            this.errorHandler.handle.bind(this.errorHandler),
         );
         // Gets data for default filter switzerland-all
         const resistancePromise = resistanceFetcher.getData();
@@ -143,8 +145,15 @@ export default class InfectApp {
         log('Fetching data for resistances.');
         log('Fetchers setup done.');
 
-        return Promise.all([substanceClassesPromise, antibioticPromise, bacteriaPromise,
-            resistancePromise]);
+        return Promise
+            .all([
+                substanceClassesPromise,
+                antibioticPromise,
+                bacteriaPromise,
+                resistancePromise,
+            ])
+            // Catch and display error; if we don't, app will fail half-way because we're async.
+            .catch(err => this.errorHandler.handle(err));
 
     }
 

--- a/src/models/antibiotics/antibioticsFetcher.integration.js
+++ b/src/models/antibiotics/antibioticsFetcher.integration.js
@@ -1,71 +1,182 @@
 import test from 'tape';
+import fetchMock from 'fetch-mock';
 import AntibioticsStore from './antibioticsStore';
 import SubstanceClass from './substanceClass';
 import SubstanceClassesStore from './substanceClassesStore';
 import AntibioticsFetcher from './antibioticsFetcher';
-import fetchMock from 'fetch-mock';
 
 // Fetch-mock does not reset itself if there's no global fetch
 const originalFetch = global.fetch;
 
+function setupData() {
+    const apiData = [{
+        id: 1,
+        substance: [{
+            substanceClass: {
+                id: 5,
+            },
+        }],
+        name: 'testAB',
+        intravenous: true,
+        perOs: false,
+        identifier: 'testId',
+    }];
+    const errors = [];
+    const errorHandler = err => errors.push(err);
+    const antibioticsStore = new AntibioticsStore();
+    const substanceClassesStore = new SubstanceClassesStore();
+    return {
+        apiData,
+        errorHandler,
+        errors,
+        antibioticsStore,
+        substanceClassesStore,
+    };
+}
+
 test('handles antibacteria data correctly', (t) => {
-	fetchMock.mock('/test', [{
-			id: 1,
-			substance: [{
-				substanceClass: {
-					id: 5
-				}
-			}],
-			name: 'testAB',
-			intravenous: true,
-			perOs: false,
-			identifier: 'testId',
-		}]);
-	const abStore = new AntibioticsStore();
-	const scStore = new SubstanceClassesStore();
-	scStore.add(new SubstanceClass(5, 'testSC'));
-	const fetcher = new AntibioticsFetcher('/test', abStore, {}, [], scStore);
-	fetcher.getData();
-	setTimeout(() => {
-		t.equals(abStore.get().size, 1);
-		t.equals(abStore.getById(1).name, 'testAB');
-		t.equals(abStore.getById(1).iv, true);
-		t.equals(abStore.getById(1).identifier, 'testId');
-		t.equals(abStore.getById(1).substanceClass.id, 5);
-		fetchMock.restore();
-		t.end();
-	});
+    const { apiData, antibioticsStore, substanceClassesStore } = setupData();
+    fetchMock.mock('/test', apiData);
+    substanceClassesStore.add(new SubstanceClass(5, 'testSC'));
+    const fetcher = new AntibioticsFetcher(
+        '/test',
+        antibioticsStore,
+        {},
+        [],
+        substanceClassesStore,
+    );
+    fetcher.getData().then(() => {
+        t.equals(antibioticsStore.get().size, 1);
+        t.equals(antibioticsStore.getById(1).name, 'testAB');
+        t.equals(antibioticsStore.getById(1).iv, true);
+        t.equals(antibioticsStore.getById(1).identifier, 'testId');
+        t.equals(antibioticsStore.getById(1).substanceClass.id, 5);
+        fetchMock.restore();
+        global.fetch = originalFetch;
+        t.end();
+    });
 });
 
 
-test('handles special cases correctly', (t) => {
-	// Prefer 'amoxicillin' in special case where 2 substance classes are available
-	fetchMock.mock('/test', [{
-			id: 1,
-			substance: [{
-				identifier: 'invalid',
-			}, {
-				identifier: 'amoxicillin',
-				substanceClass: {
-					id: 5,
-				},
-			}],
-			name: 'testAB',
-			intravenous: true,
-			perOs: false,
-			identifier: 'amoxicillin/clavulanate',
-		}]);
-	const abStore = new AntibioticsStore();
-	const scStore = new SubstanceClassesStore();
-	scStore.add(new SubstanceClass(-1, 'testSC'));
-	const fetcher = new AntibioticsFetcher('/test', abStore, {}, [], scStore);
-	fetcher.getData();
-	setTimeout(() => {
-		t.equals(abStore.get().size, 1);
-		t.equals(abStore.getById(1).substanceClass.id, -1);
-		fetchMock.restore();
-		global.fetch = originalFetch;
-		t.end();
-	});
+test('handles antibiotics with missing substance correctly', (t) => {
+    const {
+        apiData,
+        errors,
+        errorHandler,
+        antibioticsStore,
+        substanceClassesStore,
+    } = setupData();
+    apiData[0].substance = [];
+    fetchMock.mock('/test', apiData);
+    const fetcher = new AntibioticsFetcher(
+        '/test',
+        antibioticsStore,
+        {},
+        [],
+        substanceClassesStore,
+        errorHandler,
+    );
+    fetcher.getData().then(() => {
+        t.is(errors.length, 1);
+        t.is(errors[0].message.includes('has no substance data'), true);
+        // Antibiotic should not be created
+        t.is(antibioticsStore.getAsArray().length, 0);
+        fetchMock.restore();
+        global.fetch = originalFetch;
+        t.end();
+    });
 });
+
+test('handles antibiotics with multiple substances correctly', (t) => {
+    const {
+        apiData,
+        errors,
+        errorHandler,
+        antibioticsStore,
+        substanceClassesStore,
+    } = setupData();
+    apiData[0].substance.push({ substanceClass: { id: 6 } });
+    fetchMock.mock('/test', apiData);
+    substanceClassesStore.add(new SubstanceClass(5, 'testSC'));
+    const fetcher = new AntibioticsFetcher(
+        '/test',
+        antibioticsStore,
+        {},
+        [],
+        substanceClassesStore,
+        errorHandler,
+    );
+    fetcher.getData().then(() => {
+        t.is(errors.length, 1);
+        t.is(errors[0].message.includes('has more than one substance'), true);
+        // Antibiotic should be created
+        t.is(antibioticsStore.getAsArray().length, 1);
+        fetchMock.restore();
+        global.fetch = originalFetch;
+        t.end();
+    });
+});
+
+test('handles antibiotics with missing substanceClass data correctly', (t) => {
+    const {
+        apiData,
+        errors,
+        errorHandler,
+        antibioticsStore,
+        substanceClassesStore,
+    } = setupData();
+    apiData[0].substance[0] = {};
+    fetchMock.mock('/test', apiData);
+    substanceClassesStore.add(new SubstanceClass(5, 'testSC'));
+    const fetcher = new AntibioticsFetcher(
+        '/test',
+        antibioticsStore,
+        {},
+        [],
+        substanceClassesStore,
+        errorHandler,
+    );
+    fetcher.getData().then(() => {
+        t.is(errors.length, 1);
+        t.is(errors[0].message.includes('has invalid substanceClass data'), true);
+        // Antibiotic should be created
+        t.is(antibioticsStore.getAsArray().length, 0);
+        fetchMock.restore();
+        global.fetch = originalFetch;
+        t.end();
+    });
+});
+
+test('handles antibiotics with missing substanceClass correctly', (t) => {
+    const {
+        apiData,
+        errors,
+        errorHandler,
+        antibioticsStore,
+        substanceClassesStore,
+    } = setupData();
+    fetchMock.mock('/test', apiData);
+    const fetcher = new AntibioticsFetcher(
+        '/test',
+        antibioticsStore,
+        {},
+        [],
+        substanceClassesStore,
+        errorHandler,
+    );
+    fetcher.getData().then(() => {
+        t.is(errors.length, 1);
+        t.is(
+            errors[0].message.includes('AntibioticsFetcher: Substance class with ID 5 not found'),
+            true,
+        );
+        // Antibiotic should not be created
+        t.is(antibioticsStore.getAsArray().length, 0);
+        fetchMock.restore();
+        global.fetch = originalFetch;
+        t.end();
+    });
+});
+
+
 

--- a/src/models/antibiotics/antibioticsFetcher.js
+++ b/src/models/antibiotics/antibioticsFetcher.js
@@ -3,60 +3,75 @@ import Antibiotic from './antibiotic';
 
 export default class AntibioticsFetcher extends Fetcher {
 
-	constructor(...args) {
-		super(...args.slice(0, 4));
-		this._substanceClasses = args[4];
-	}
+    constructor(...args) {
+        super(...args.slice(0, 4));
+        this.substanceClasses = args[4];
+        this.handleError = args[5];
+    }
 
-	_handleData(data) {
+    _handleData(data) {
 
-		// Remove penicillin v and Cefuroxime Axetil (they contain no data)
-		let i = data.length;
-		while (i--) {
-			if (data[i].identifier === 'penicillin v' || data[i].identifier === 
-				'cefuroxime axetil') {
-				data.splice(i, 1);
-			}
-		}
+        // Cone data as we're modifying it
+        data.forEach((item) => {
 
+            // There are 2 special cases: amoxicillin/clavulanate and piperacillin/tazobactam
+            // get a «virtual» substance class Beta-lactam + inhibitor that was programmatically
+            // created in SubstanceClassFetcher
+            if (
+                item.identifier === 'amoxicillin/clavulanate' ||
+                item.identifier === 'piperacillin/tazobactam'
+            ) {
+                item.substance = [{
+                    substanceClass: {
+                        id: -1,
+                    },
+                }];
+            }
 
+            if (!item.substance.length) {
+                const err = new Error(`antibioticsFetcher: Compound ${JSON.stringify(item)} has no substance data. Cannot be displayed.`);
+                this.handleError(err);
+                return;
+            }
 
-		// Cone data as we're modifying it
-		data.forEach((item) => {
+            // More than one substance. Just display error (as we won't use substances with
+            // index > 0), but add antibiotic.
+            if (item.substance.length > 1) {
+                const err = new Error(`antibioticsFetcher: Compound ${JSON.stringify(item)} has more than one substance; this is not expected.`);
+                this.handleError(err);
+            }
 
-			// There are 2 special cases: amoxicillin/clavulanate and piperacillin/tazobactam
-			// get a «virtual» substance class Beta-lactam + inhibitor that was programmatically
-			// created in SubstanceClassFetcher
-			if (item.identifier === 'amoxicillin/clavulanate' || item.identifier ===
-				'piperacillin/tazobactam') {
-				item.substance = [{
-					substanceClass: {
-						id: -1,
-					}
-				}];
-			}
+            // substance hasOne substanceClass – no need to validate data. But check if
+            // substanceClass exists on API data. Handle gracefully.
+            if (!item.substance[0].substanceClass) {
+                const err = new Error(`antibioticsFetcher: Substance ${JSON.stringify(item.substance[0])} has invalid substanceClass data.`);
+                this.handleError(err);
+                return;
+            }
+            const substanceClassId = item.substance[0].substanceClass.id;
 
-			if (item.substance.length !== 1) console.warn(`antibioticsFetcher: Compound with 
-				identifier ${ item.identifier } has more or less than one substance; this is 
-				not expected. Only Amoxi & Pip can contain two substances.`);
+            // Substance class does not exist: Handle gracefully.
+            const substanceClass = this.substanceClasses.getById(substanceClassId);
+            if (!substanceClass) {
+                const err = new Error(`AntibioticsFetcher: Substance class with ID ${substanceClassId} not found.`);
+                // Display helpful error in console for easier debugging
+                console.error(
+                    'AntibioticsFetcher: Substance class for %o not found within %o.',
+                    item.substance[0],
+                    this.substanceClasses.getAsArray(),
+                );
+                this.handleError(err);
+                return;
+            }
 
-			// substance hasOne substanceClass – no need to validate data
-			if (!item.substance[0].substanceClass) {
-				throw new Error(`antibioticsFetcher: Substance 
-					${ JSON.stringify(item.substance[0]) } has bad substanceClass data.`);
-			}
-			const substanceClassId = item.substance[0].substanceClass.id;
+            const antibiotic = new Antibiotic(item.id, item.name, substanceClass, {
+                iv: item.intravenous,
+                po: item.perOs,
+                identifier: item.identifier,
+            });
 
-			const substanceClass = this._substanceClasses.getById(substanceClassId);
-			if (!substanceClass) throw new Error(`AntibioticsFetcher: Substance class with ID 
-				${ substanceClassId } not found.`);
-			const antibiotic = new Antibiotic(item.id, item.name, substanceClass, {
-				iv: item.intravenous,
-				po: item.perOs,
-				identifier: item.identifier,
-			});
-			this._store.add(antibiotic);
-		});
-	}
+            this._store.add(antibiotic);
+        });
+    }
 
 }

--- a/src/models/errorHandler/errorHandler.js
+++ b/src/models/errorHandler/errorHandler.js
@@ -5,6 +5,9 @@ class ErrorHandler {
     @observable errors = [];
 
     @action handle(err) {
+        // Make sure errors are also propagated to online tools (that are mostly watching
+        // console.error for output)
+        console.error(err);
         this.errors.push(err);
     }
 

--- a/src/models/resistances/resistancesFetcher.integration.js
+++ b/src/models/resistances/resistancesFetcher.integration.js
@@ -3,12 +3,11 @@ import fetchMock from 'fetch-mock';
 import ResistancesFetcher from './resistancesFetcher';
 import Store from '../../helpers/store';
 import Bacterium from '../bacteria/bacterium';
-import { observable } from 'mobx';
 
 // Fetch-mock does not reset itself if there's no global fetch
 const originalFetch = global.fetch;
 
-function setupFetcher() {
+function setupStores() {
     const antibiotics = {
         get() {
             return {
@@ -54,20 +53,18 @@ function setupBodyData() {
     };
 }
 
-test('handles resistance data correctly', async (t) => {
+test('handles resistance data correctly', async(t) => {
     fetchMock.mock('/test', {
         status: 200,
         body: setupBodyData(),
     });
-    const { antibiotics, bacteria } = setupFetcher();
+    const { antibiotics, bacteria } = setupStores();
     const store = new Store([], () => 2);
     const stores = {
         antibiotics,
         bacteria,
     };
-    const fetcher = new ResistancesFetcher('/test', store, {}, [], stores, {
-        getFiltersByType: () => {},
-    });
+    const fetcher = new ResistancesFetcher('/test', store, {}, [], stores, () => {});
     await fetcher.getData();
     t.equals(store.get().size, 1);
     const result = store.getById(2);
@@ -80,7 +77,7 @@ test('handles resistance data correctly', async (t) => {
 });
 
 
-test('handles filter updates', async (t) => {
+test('handles filter updates', async(t) => {
 
     const filterData = setupBodyData();
     filterData.values[0].resistantPercent = 99;
@@ -89,26 +86,20 @@ test('handles filter updates', async (t) => {
         .mock('/test?filter={"region":[3,6]}', {
             status: 200,
             body: filterData,
-        }/*, {
-            headers: {
-                filter: '{"region":[3,6]}',
-            },
-        }*/)
+        })
         .mock('/test', {
             status: 200,
             body: setupBodyData(),
         });
 
 
-    const { antibiotics, bacteria } = setupFetcher();
+    const { antibiotics, bacteria } = setupStores();
     const store = new Store([], () => 2);
     const stores = {
         antibiotics,
         bacteria,
     };
-    const fetcher = new ResistancesFetcher('/test', store, {}, [], stores, {
-        getFiltersByType: () => {},
-    });
+    const fetcher = new ResistancesFetcher('/test', store, {}, [], stores);
 
     await fetcher.getData();
     t.equals(store.getById(2).values[0].value, 1);
@@ -126,5 +117,64 @@ test('handles filter updates', async (t) => {
 
 });
 
+test('handles missing antibiotics/bacteria gracefully', async(t) => {
+
+    const recordedErrors = [];
+    const handleError = err => recordedErrors.push(err);
+
+    // Create API endpoint that returns a resistance with invalid compoundId and bacteriumId
+    fetchMock
+        .mock('/invalidBacterium', {
+            status: 200,
+            body: {
+                values: [{
+                    bacteriumId: -1,
+                    compoundId: 4,
+                }],
+            },
+        })
+        .mock('/invalidAntibiotic', {
+            status: 200,
+            body: {
+                values: [{
+                    bacteriumId: 5,
+                    compoundId: -1,
+                }],
+            },
+        });
+
+    const { antibiotics, bacteria } = setupStores();
+    const store = new Store([], () => 2);
+    const stores = {
+        antibiotics,
+        bacteria,
+    };
+
+    const bacteriaFetcher = new ResistancesFetcher(
+        '/invalidBacterium',
+        store,
+        {},
+        [],
+        stores,
+        handleError,
+    );
+    const antibioticsFetcher = new ResistancesFetcher(
+        '/invalidAntibiotic',
+        store,
+        {},
+        [],
+        stores,
+        handleError,
+    );
+
+    await bacteriaFetcher.getData();
+    await antibioticsFetcher.getData();
+
+    t.is(recordedErrors.length, 2);
+    t.is(recordedErrors[0].message.includes('Bacterium with ID -1 missing'), true);
+    t.is(recordedErrors[1].message.includes('Antibiotic with ID -1 missing'), true);
+    t.end();
+
+});
 
 

--- a/src/models/resistances/resistancesFetcher.js
+++ b/src/models/resistances/resistancesFetcher.js
@@ -13,13 +13,13 @@ export default class ResistancesFetcher extends Fetcher {
     * Fetches resistances from server, then updates ResistancesStore passed as an argument.
     *
     * @param [0-3]                              See Fetcher
-    * @param {ResistanceStore} stores           Stores for antibiotics and bacteria
-    * @param {SelectedFilters} selectedFilters  Selected filters – needed to determine which
-    *                                           resistance data (e.g. region) to fetch.
+    * @param {ResistanceStore} stores           Stores for antibiotics *and* bacteria
+    * @param {Function} handleError             Function that gently handles non-critical exceptions
     */
-    constructor(url, store, options, dependentStores, stores) {
+    constructor(url, store, options, dependentStores, stores, handleError) {
         super(url, store, options, dependentStores);
         this._stores = stores;
+        this.handleError = handleError;
     }
 
 
@@ -47,8 +47,7 @@ export default class ResistancesFetcher extends Fetcher {
 
         // On the very first round (when we're getting data for switzerland-all) remove all
         // antibiotics that don't have any resistance data.
-        // TODO: We need a good endpoint which only returns ab/bact with data available. This
-        // is bullshit.
+        // TODO: We need a good endpoint which only returns ab/bact with data available.
         if (this.dataHandled === 1) {
 
             const emptyBacteria = bacteria
@@ -56,7 +55,7 @@ export default class ResistancesFetcher extends Fetcher {
                 .filter(bacterium => !data.values.find(res => res.bacteriumId === bacterium.id));
 
             if (emptyBacteria.length) {
-                log('Remove empty bacteria %o', bacteria);
+                log('Remove empty bacteria %o', emptyBacteria);
             }
 
             // Remove bacterium from store which triggers removal from matrixView – do it in
@@ -84,23 +83,27 @@ export default class ResistancesFetcher extends Fetcher {
             // ee [4:38 PM]
             // iu
             // müssen wir dann noch anschauen
-            if (!resistance.compoundId) {
-                console.warn(`ResistanceFetcher: Resistance %o does not have compound information;
-                    ignore for now, but should be fixed.`);
+            if (!Object.prototype.hasOwnProperty.call(resistance, 'compoundId')) {
+                console.error(`ResistanceFetcher: Resistance ${JSON.stringify(resistance)} does not have compound information; ignore for now, but should be fixed.`);
                 return;
             }
 
             const bacterium = bacteria.find(item => item.id === resistance.bacteriumId);
             const antibiotic = antibiotics.find(item => item.id === resistance.compoundId);
 
+            // Missing bacterium or antibiotic is not crucial; display error but continue
             if (!antibiotic) {
-                throw new Error(`ResistancesFetcher: Antibiotic missing for 
-                    ${JSON.stringify(resistance)} %o`);
+                const antibioticMissingError = new Error(`ResistancesFetcher: Antibiotic with ID ${resistance.compoundId} missing, resistance ${JSON.stringify(resistance)} cannot be displayed.`);
+                this.handleError(antibioticMissingError);
+                console.error('Antibiotic for resistance %o missi/ng; antibiotics are %o', resistance, antibiotics);
+                return;
             }
 
             if (!bacterium) {
-                throw new Error(`ResistancesFetcher: Bacterium missing for 
-                    ${JSON.stringify(resistance)}`);
+                const bacteriumMissingError = new Error(`ResistancesFetcher: Bacterium with ID ${resistance.bacteriumId} missing, resistance ${JSON.stringify(resistance)} cannot be displayed.`);
+                this.handleError(bacteriumMissingError);
+                console.error('Bacterium for resistance %o missing; bacteria are %o', resistance, bacteria);
+                return;
             }
 
             const resistanceValues = [{
@@ -116,8 +119,7 @@ export default class ResistancesFetcher extends Fetcher {
 
             // Duplicate resistance
             if (this._store.hasWithId(resistanceObject)) {
-                console.warn(`ResistanceFetcher: Resistance ${JSON.stringify(resistance)} is
-                    a duplicate; an entry for the same bacterium and antibiotic does exist.`);
+                console.warn(`ResistanceFetcher: Resistance ${JSON.stringify(resistance)} is a duplicate; an entry for the same bacterium and antibiotic does exist.`);
                 return;
             }
 


### PR DESCRIPTION
1. handle exceptions gently for antibiotics (if e.g. substance class is missing) and resistances (if e.g. bacterium is missing)
2. make sure new data works (by not removing `cefuroxime axetil` and `penicillin v` any more)